### PR TITLE
Missing parameter check.

### DIFF
--- a/dist/dataset.js
+++ b/dist/dataset.js
@@ -35,7 +35,7 @@ define(["require", "exports", "knockout", "underscore", "promise/extensions", ".
 
     function _updateDataSet(dataset, result, query) {
         var rmDfd, isArray = _.isArray(result.data);
-        if (isArray && !query || query.pageSize() === 0) {
+        if (isArray && !query || query && query.pageSize() === 0) {
             var current = dataset.toArray();
             if (query && query.filters.size() > 0)
                 current = query.applyFilters(current);

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -202,7 +202,7 @@ function _initAttachedEntity(dataset: DataSet<any, any>, entity: any): any {
 
 function _updateDataSet(dataset: DataSet<any, any>, result: adapters.IAdapterResult, query: query.ODataQuery): Promise<any[]> {
     var rmDfd, isArray = _.isArray(result.data);
-    if (isArray && !query || query.pageSize() === 0) {
+    if (isArray && !query || query && query.pageSize() === 0) {
         var current = dataset.toArray();
         if (query && query.filters.size() > 0)
             current = query.applyFilters(current);


### PR DESCRIPTION
Error occurs when updating dataset after a getRelation on a many-to-one relation: the result.data is not an array & the query parameter might be empty
